### PR TITLE
Dependency Injection: Clarify all actors have to be registered as transient service

### DIFF
--- a/hugo/content/docs/di.md
+++ b/hugo/content/docs/di.md
@@ -47,7 +47,9 @@ First, let's take a look at how to configure a Proto.Actor to use DI. We need to
 services.AddSingleton(serviceProvider => new ActorSystem().WithServiceProvider(serviceProvider));
 ```
 
-Then we register the service of `DependencyInjectedActor` type with a transient lifetime. 
+Then register all actors with a transient lifetime.
+
+For example, if we have an actor of type `DependencyInjectedActor`, register the type with a transient lifetime. 
 
 ```csharp
 services.AddTransient<DependencyInjectedActor>();


### PR DESCRIPTION
When setting up DependencyInjection  in my environment I searched for DependencyInjectedActor. I thought this is part of the infrastructure.
I propose to explitly state, that DependencyInjectedActor is an example.