### PR TITLE
docs: add cross-language example links

### DIFF
--- a/hugo/content/docs/chatexample/_index.md
+++ b/hugo/content/docs/chatexample/_index.md
@@ -51,7 +51,7 @@ We can then take these contracts and use gRPC in order to generate clients and s
 
 ## High-Level Overview of Our Chat Example
 
-You can find the example on github [here](https://github.com/aneshas/protoactor-dotnet/tree/chat-example-refactor/examples/Chat).
+You can find full source code on GitHub for both runtimes: [.NET](https://github.com/asynkron/protoactor-dotnet/tree/dev/examples/Chat) | [Go](https://github.com/asynkron/protoactor-go/tree/dev/examples/remote-chat).
 ![Proto.Remote](chat-overview.png)
 As shown in the picture, our chat example will consist of client and server actors distributed over the network communicating via `Proto.Remote` library.
 
@@ -464,9 +464,12 @@ If the user tries to change the default nick by using /nick command, we parse th
 
 At last, if the user types in some unstructured text we it is a chat message pass it along as such to the server via SayRequest message. Remember that we wired up our client actor to receive messages from the server and print them out to the console.
 
-## Go Example Source
+## Example Source Code
 
-As stated before, client and server might as well be built using different languages and interact with each other just as well. In fact, there is the same chat example written in `Go` [hosted here](https://github.com/asynkron/protoactor-go/tree/dev/examples/remote-chat).
+As stated before, client and server might as well be built using different languages and interact with each other just as well. Full implementations are available on GitHub:
+
+- [.NET Chat example](https://github.com/asynkron/protoactor-dotnet/tree/dev/examples/Chat)
+- [Go Chat example](https://github.com/asynkron/protoactor-go/tree/dev/examples/remote-chat)
 
 This brings us to the end of the tour of our chat example. Hope you enjoyed it.
 

--- a/hugo/content/docs/cluster.md
+++ b/hugo/content/docs/cluster.md
@@ -11,6 +11,13 @@ tags: [protoactor, docs]
 
 <small>[Homage to Proto.Actors Swedish roots, Swedish midsummer ring dance - Connected Cluster Actors]</small>
 
+## Example Source Code
+
+Working cluster examples are available on GitHub:
+
+- [.NET cluster example](https://github.com/asynkron/protoactor-dotnet/tree/dev/examples/ClusterGrainHelloWorld)
+- [Go cluster example](https://github.com/asynkron/protoactor-go/tree/dev/examples/cluster-basic)
+
 ## Virtual Actors, aka. Grains
 
 Proto.Cluster leverages the _"Virtual Actor Model"_, pioneered by Microsoft Orleans.

--- a/hugo/content/docs/cluster/getting-started-go.md
+++ b/hugo/content/docs/cluster/getting-started-go.md
@@ -14,7 +14,7 @@ In this tutorial we will:
 3. Send messages to and between these grains.
 4. Host everything in a simple Go app.
 
-The code from this tutorial is available [on GitHub](https://github.com/asynkron/protoactor-go/tree/dev/examples/cluster-grain).
+The code from this tutorial is available on GitHub: [Go version](https://github.com/asynkron/protoactor-go/tree/dev/examples/cluster-grain) | [.NET version](https://github.com/asynkron/protoactor-dotnet/tree/dev/examples/ClusterGrainHelloWorld).
 
 ## Setting up the project
 

--- a/hugo/content/docs/cluster/getting-started-net.md
+++ b/hugo/content/docs/cluster/getting-started-net.md
@@ -12,7 +12,7 @@ In this tutorial we will:
 1. Send messages to and between these grains.
 1. Host everything in a simple ASP.NET Core app.
 
-The code from this tutorial is available [on GitHub](https://github.com/asynkron/protoactor-grains-tutorial).
+The code from this tutorial is available on GitHub: [.NET version](https://github.com/asynkron/protoactor-dotnet/tree/dev/examples/ClusterGrainHelloWorld) | [Go version](https://github.com/asynkron/protoactor-go/tree/dev/examples/cluster-grain).
 
 ## Setting up the project
 

--- a/hugo/content/docs/getting-started.md
+++ b/hugo/content/docs/getting-started.md
@@ -124,3 +124,10 @@ func main() {
 
 You've now created and run your first Proto.Actor program in both .NET and Go. This simple example forms the foundation for building resilient, concurrent applications that scale across cores and machines.
 
+## Example Source Code
+
+Working implementations are available on GitHub:
+
+- [.NET greeter example](https://github.com/asynkron/protoactor-dotnet/tree/dev/examples/HelloWorld)
+- [Go greeter example](https://github.com/asynkron/protoactor-go/tree/dev/examples/actor-helloworld)
+

--- a/hugo/content/docs/hello-world.md
+++ b/hugo/content/docs/hello-world.md
@@ -167,3 +167,10 @@ time.Sleep(1 * time.Second)
 When you run the code, the `HelloWorldActor` will receive and process the `Hello` message, and you should see "Hello World" printed on the console.
 
 That's it! You've successfully created a basic Proto.Actor example. Feel free to explore further and create more complex systems using the powerful features provided by Proto.Actor.
+
+## Example Source Code
+
+Complete implementations are available on GitHub:
+
+- [.NET HelloWorld example](https://github.com/asynkron/protoactor-dotnet/tree/dev/examples/HelloWorld)
+- [Go HelloWorld example](https://github.com/asynkron/protoactor-go/tree/dev/examples/actor-helloworld)

--- a/hugo/content/docs/supervision.md
+++ b/hugo/content/docs/supervision.md
@@ -11,6 +11,13 @@ This document outlines the concept behind supervision and what that means for yo
 
 ![supervision](images/Supervision-all-blue.png)
 
+## Example Source Code
+
+Practical implementations are available on GitHub:
+
+- [.NET Supervision example](https://github.com/asynkron/protoactor-dotnet/tree/dev/examples/Supervision)
+- [Go Supervision example](https://github.com/asynkron/protoactor-go/tree/dev/examples/actor-supervision)
+
 ## What Supervision means
 
 Supervision describes a dependency relationship between actors: the supervisor delegates tasks to subordinates and therefore must respond to their failures. When a subordinate detects a failure (i.e. throws an exception), it suspends itself and all its subordinates and sends a message to its supervisor, signaling failure. Depending on the nature of the work to be supervised and the nature of the failure, the supervisor has a choice of the following four options:


### PR DESCRIPTION
## Summary
- link Hello World and getting started guides to official Go and .NET example code
- add cross-language example references for chat, cluster, and supervision documentation
- connect cluster tutorials to example source for both runtimes

## Testing
- `hugo --panicOnWarning`

------
https://chatgpt.com/codex/tasks/task_e_68999d6dc14483288d740a4f8b8d9e9c