### PR TITLE
Fix Bootcamp 2025 chapter layout and code formatting

### DIFF
--- a/hugo/content/docs/bootcamp2025/chapter-1.md
+++ b/hugo/content/docs/bootcamp2025/chapter-1.md
@@ -1,6 +1,7 @@
 # Chapter 1: Introduction to the Actor Model and Proto.Actor
 
 **Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
+
 The actor model is a conceptual model for designing concurrent, distributed systems. In the actor model, an actor is a lightweight entity that encapsulates state and behavior, and communicates exclusively by exchanging messages. Actors do not share memory; instead, they send messages to each other asynchronously. This eliminates the need for locks or manual thread management, since each actor processes one message at a time in a single-threaded manner. The actor model provides a high-level abstraction for concurrency, making it easier to build systems that are responsive, resilient, and elastic (as advocated by the Reactive Manifesto). Key benefits of using the actor model include:
 
 - Simplified Concurrency: No explicit threads or locks — actors run independently and handle messages sequentially, avoiding race conditions by design.

--- a/hugo/content/docs/bootcamp2025/chapter-2.md
+++ b/hugo/content/docs/bootcamp2025/chapter-2.md
@@ -1,6 +1,7 @@
 # Chapter 2: Proto.Actor Core Primitives
 
 **Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
+
 Now that we understand the basic actor model, let’s see how Proto.Actor implements these concepts and what core primitives it provides. We will cover how to define an actor’s behavior, how to create and start actors, how actors send and receive messages, and how the actor lifecycle and hierarchy work. We’ll illustrate with simple examples in C# and Go.
 
 ## Actors, Messages, and the Actor System
@@ -189,19 +190,19 @@ Proto.Actor actors have a well-defined lifecycle. They go through stages such as
 
 The context (`IContext` in C#, `actor.Context` in Go) passed to the actor’s receive method provides methods to interact with the actor system during those lifecycle events and beyond:
 
-- ctx.Self – the `PID` of the current actor (itself).
+- `ctx.Self` – the `PID` of the current actor (itself).
 
-- ctx.Sender – the `PID` of the actor that sent the current message (if available). Using ctx.Respond(msg) in C# (or ctx.Respond(msg) in Go) will send a response back to the Sender.
+- `ctx.Sender` – the `PID` of the actor that sent the current message (if available). Using `ctx.Respond(msg)` in C# (or `ctx.Respond(msg)` in Go) will send a response back to the `Sender`.
 
-- ctx.Spawn(props) – spawn a new child actor under the current actor. The new actor’s parent will be the current actor, meaning if the current actor stops, it will stop its children as well.
+- `ctx.Spawn(props)` – spawn a new child actor under the current actor. The new actor’s parent will be the current actor, meaning if the current actor stops, it will stop its children as well.
 
-- ctx.Stop(targetPid) – stop a child actor (or you can stop ctx.Self to stop itself). Stopping an actor will eventually send it a Stopped message and terminate it after it processes current messages.
+- `ctx.Stop(targetPid)` – stop a child actor (or you can stop `ctx.Self` to stop itself). Stopping an actor will eventually send it a `Stopped` message and terminate it after it processes current messages.
 
-- ctx.SetReceiveTimeout(duration) – if set, if the actor doesn’t receive any message for the given duration, it will get a ReceiveTimeout message. This is useful to implement auto-shutdown of idle actors, etc.
+- `ctx.SetReceiveTimeout(duration)` – if set, if the actor doesn’t receive any message for the given duration, it will get a `ReceiveTimeout` message. This is useful to implement auto-shutdown of idle actors, etc.
 
-- ctx.Forward(pid, message) – forward the exact message (and original sender) to another actor.
+- `ctx.Forward(pid, message)` – forward the exact message (and original sender) to another actor.
 
-- ctx.Watch(targetPid) – watch another actor; you will get a Terminated message if that actor stops (this is useful for monitoring lifecycles).
+- `ctx.Watch(targetPid)` – watch another actor; you will get a `Terminated` message if that actor stops (this is useful for monitoring lifecycles).
 
 These are just a few highlights of the context API. The context is powerful: it’s your interface to the actor system from within the actor. For example, an actor can spawn children to delegate work, and if a child crashes, the parent will be notified via a Terminated message – at which point the parent can decide to spawn a new child or handle the error. This ties into supervision.
 

--- a/hugo/content/docs/bootcamp2025/chapter-3.md
+++ b/hugo/content/docs/bootcamp2025/chapter-3.md
@@ -1,6 +1,7 @@
 # Chapter 3: Remoting with Proto.Actor (Proto.Remote)
 
 **Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
+
 Thus far, our actors have all been within a single process. One of the powerful features of Proto.Actor is that it supports location transparency not just in theory but in practice: you can have actors running on different machines (or processes) communicate with each other. Proto.Actor’s Remoting module (often referred to as Proto.Remote) provides the networking layer to send messages between actor systems over the network (using gRPC under the hood). In this chapter, we’ll cover how to set up remoting, how remote actors are addressed, and a simple example of sending messages between two processes (in C# and Go).
 
 ## Why Remoting?

--- a/hugo/content/docs/bootcamp2025/chapter-4.md
+++ b/hugo/content/docs/bootcamp2025/chapter-4.md
@@ -1,6 +1,7 @@
 # Chapter 4: Building Distributed Solutions with Proto.Cluster (Virtual Actors)
 
 **Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
+
 While Proto.Remote allows point-to-point communication between known nodes, Proto.Cluster builds on top of it to provide a higher-level abstraction for distributed systems: clusters of virtual actors. In Proto.Cluster, actors can be addressed by a logical identity (like “user/123”) rather than a physical PID. The cluster takes care of finding or activating an actor with that identity on some node, and routing messages to it. This greatly simplifies building scalable systems, as you do not need to manually track where each actor lives or whether it’s running – the cluster does it for you. In this chapter, we’ll explain key concepts of Proto.Cluster (cluster identities, kinds, membership, etc.), how virtual actors (grains) work, and how to configure and use a Proto.Actor cluster in C# and Go.
 
 ## Why Use a Cluster?

--- a/hugo/content/docs/bootcamp2025/chapter-5.md
+++ b/hugo/content/docs/bootcamp2025/chapter-5.md
@@ -1,6 +1,7 @@
 # Chapter 5: Testing Proto.Actor Systems with Proto.TestKit
 
 **Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
+
 Testing is a crucial part of developing reliable systems. Actor-based systems introduce concurrency, which can make testing tricky if you try to do it with traditional approaches (like expecting results immediately, or trying to synchronize threads manually). Proto.Actor provides the Proto.TestKit module (for .NET and Go) to assist in writing tests for actors. In this chapter, we’ll cover how to use test kit features such as test probes to capture messages, how to simulate timings, and general strategies for testing actors, both in isolation and as part of a system.
 
 ## Challenges in Testing Actors


### PR DESCRIPTION
## Summary
- add blank line after chapter navigation in Bootcamp 2025 pages
- format context API bullet list with code font in chapter 2

## Testing
- `cd hugo && hugo >/tmp/hugo.log && tail -n 20 /tmp/hugo.log`


------
https://chatgpt.com/codex/tasks/task_e_68ab190c56748328903056ab70f3ebb9